### PR TITLE
Add KnownAudioExtension type and refactor MIME type handling

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -14,3 +14,13 @@ export interface TranscriptionConfig {
 	style?: TranscriptionStyle;
 	language?: string | null;
 }
+
+
+export type KnownAudioExtension =
+	| ".mp3"
+	| ".wav"
+	| ".aac"
+	| ".flac"
+	| ".ogg"
+	| ".webm"
+	| ".weba";

--- a/src/utils/file-helper.ts
+++ b/src/utils/file-helper.ts
@@ -1,55 +1,45 @@
 import * as path from "node:path";
+import { KnownAudioExtension } from "../types";
 
 interface CustomFileOptions extends BlobPropertyBag {
-	lastModified?: number; // Optional last modified timestamp
+	lastModified?: number;
 }
 
 export class CustomFile extends Blob {
-	public readonly name: string;
-	public readonly lastModified: number;
+	readonly name: string;
+	readonly lastModified: number;
 
-	/**
-	 * Creates a new CustomFile instance.
-	 * @param fileBits An array of BlobParts (ArrayBuffer, ArrayBufferView, Blob, string) that will be put into the file.
-	 * @param fileName The name of the file.
-	 * @param options Optional settings for the Blob and CustomFile.
-	 */
 	constructor(
 		fileBits: BlobPart[],
 		fileName: string,
-		options?: CustomFileOptions
+		options: CustomFileOptions = {}
 	) {
 		super(fileBits, options);
 		this.name = fileName;
-		this.lastModified = options?.lastModified ?? Date.now();
+		this.lastModified = options.lastModified ?? Date.now();
 	}
 }
+const mimeTypes: Record<KnownAudioExtension, string> = {
+	".mp3": "audio/mpeg",
+	".wav": "audio/wav",
+	".aac": "audio/aac",
+	".flac": "audio/flac",
+	".ogg": "audio/ogg",
+	".webm": "audio/webm",
+	".weba": "audio/webm",
+};
 
-/**
- * Determines the MIME type of a file based on its extension.
- * @param filePath The path to the file.
- * @returns The determined MIME type as a string, or "audio/octet-stream" if unknown.
- */
 export async function getMimeType(filePath: string): Promise<string> {
-	const ext = path.extname(filePath).toLowerCase();
-	switch (ext) {
-		case ".mp3":
-			return "audio/mpeg";
-		case ".wav":
-			return "audio/wav";
-		case ".aac":
-			return "audio/aac";
-		case ".flac":
-			return "audio/flac";
-		case ".ogg":
-			return "audio/ogg";
-		case ".webm":
-		case ".weba": // Assuming .weba is also audio/webm for consistency
-			return "audio/webm";
-		default:
-			console.warn(
-				`[warn] Unknown extension '${ext}' for path '${filePath}', using fallback 'audio/octet-stream'.`
-			);
-			return "audio/octet-stream";
+	const ext = path.extname(filePath).toLowerCase() as
+		| KnownAudioExtension
+		| string;
+
+	if (ext in mimeTypes) {
+		return mimeTypes[ext as KnownAudioExtension];
+	} else {
+		console.warn(
+			`[warn] Unknown extension '${ext}' for path '${filePath}', using fallback 'audio/octet-stream'.`
+		);
+		return "audio/octet-stream";
 	}
 }


### PR DESCRIPTION
- Introduced `KnownAudioExtension` type in `src/types/index.ts` to define supported audio file extensions.
- Refactored `getMimeType` function in `src/utils/file-helper.ts` to utilize the new type for improved clarity and maintainability.
- Simplified MIME type determination by using a mapping object instead of a switch statement.