### PR TITLE
Update README and transcriber.ts to standardize API key configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,11 +52,19 @@ npm install
 
 ### 3. Setup Environment Variables
 
-Create a `.env` file in the root and add your Gemini API key:
+You can set up your Gemini API key in one of two ways:
 
-```
-GEMINI_API_KEY=your-gemini-api-key-here
-```
+1. **Environment Variable** (Recommended for production):
+
+   ```bash
+   export TRANSCRIBER_KEY=your-gemini-api-key-here
+   ```
+
+2. **.env File** (Recommended for development):
+   Create a `.env` file in your project root:
+   ```
+   TRANSCRIBER_KEY=your-gemini-api-key-here
+   ```
 
 > Get your API key from [https://makersuite.google.com/app/apikey](https://makersuite.google.com/app/apikey)
 

--- a/src/transcriber.ts
+++ b/src/transcriber.ts
@@ -3,15 +3,24 @@ import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { CustomFile, getMimeType } from "./utils/file-helper";
 import dotenv from "dotenv";
-import { TRANSCRIPTION_PROMPTS, type TranscriptionStyle } from "./utils/prompt";
-import { TranscribeAudioOptions, TranscriptionSources } from "./types";
+import { TRANSCRIPTION_PROMPTS } from "./utils/prompt";
+import { TranscribeAudioOptions } from "./types";
 
+// Try to load .env file from current working directory
 dotenv.config();
 
-const API_KEY = process.env.GEMINI_API_KEY;
+// Get API key from environment variables or .env file
+const API_KEY = process.env.TRANSCRIBER_KEY;
+
 if (!API_KEY) {
-	throw new Error("GEMINI_API_KEY is missing. Check your .env file.");
+	throw new Error(
+		"TRANSCRIBER_KEY is missing. Please set it in one of the following ways:\n" +
+			"1. Set it as an environment variable: export TRANSCRIBER_KEY=your-key-here\n" +
+			"2. Create a .env file in your project root with: TRANSCRIBER_KEY=your-key-here\n\n" +
+			"Get your API key from: https://makersuite.google.com/app/apikey"
+	);
 }
+
 const genAI = new GoogleGenAI({ apiKey: API_KEY });
 
 export async function transcribeAudio(


### PR DESCRIPTION
- Revised README.md to clarify the setup of the Gemini API key, offering two methods: as an environment variable or via a .env file.
- Updated transcriber.ts to reflect the new environment variable name (TRANSCRIBER_KEY) and improved error messaging for missing API keys.