### PR TITLE
Update sourceType terminology in transcription logic

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -65,7 +65,7 @@ export async function runTranscription(
 		const transcription: string | null = await transcribeAudio(filePath, {
 			style,
 			language,
-			sourceType: isRemote ? "supabase" : "local",
+			sourceType: isRemote ? "remote" : "local",
 		});
 
 		if (verbose) {

--- a/src/transcriber.ts
+++ b/src/transcriber.ts
@@ -38,7 +38,7 @@ export async function transcribeAudio(
 
 		let buffer: Buffer;
 
-		if (sourceType === "supabase") {
+		if (sourceType === "remote") {
 			const response = await fetch(filePath);
 			if (!response.ok) {
 				console.error(

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,6 @@
 import { TranscriptionStyle } from "../utils/prompt";
 
-export type TranscriptionSources = "local" | "supabase";
+export type TranscriptionSources = "local" | "remote";
 
 export interface TranscribeAudioOptions {
 	style?: TranscriptionStyle;


### PR DESCRIPTION
- Changed sourceType from "supabase" to "remote" in both runTranscription and transcribeAudio functions for consistency and clarity.
- Updated TranscriptionSources type to reflect the new terminology, enhancing type safety and maintainability.